### PR TITLE
Fix for "******" parse error in localmet reading ARL files

### DIFF
--- a/met/arl/arlprofiler.py
+++ b/met/arl/arlprofiler.py
@@ -327,13 +327,15 @@ class ARLProfile(object):
         return self.hourly_profile
 
     NEGATIVE_NUMBER_MATCHER = re.compile('([^E])-')
+    MISSING_VALUE_MATCHER = re.compile('\*{6}')
     def _split_hour_pressure_vals(self, line):
         # Some values occupy 6 characters, and some 8.  They are for
         # the most part separated by spaces. The one exception I've
         # found is when a negative number's '-' is right up against
         # the value to it's left; so, add an extra space before any
         # '-' and then split on space
-        return self.NEGATIVE_NUMBER_MATCHER.subn('\\1 -', line)[0].split()
+        new_line = self.NEGATIVE_NUMBER_MATCHER.sub('\\1 -', line)
+        return self.MISSING_VALUE_MATCHER.sub('  0.0 ', new_line).split()
 
     def parse_hourly_text(self, profile):
         """ Parse raw hourly text into a more useful dictionary """


### PR DESCRIPTION
Added missing value matcher to detect single/multiple instances of "******" in arl files. These occur when the "profile" fortran code encounters a missing value.

The replacement function in _split_hour_pressure_vals replaces asterisks with 0.0 in addition to splitting negative numbers from their neighbors (original function). 

Fixes the following localmet bugs:
1. "list index out of range"  (i.e., "******" not within first line of arl file)
2. "could not convert string to float: 'xxx************'"  (i.e., "******" within first line of arl file)